### PR TITLE
Add real files-mcp e2e tests

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -87,6 +87,11 @@ deployments:
       values:
         containers:
           - image: ${E2E_IMAGE}
+            env:
+              - name: FILES_ADDRESS
+                value: "files:50051"
+              - name: MCP_BASE_URL
+                value: "http://files-mcp:8100"
         labels:
           app.kubernetes.io/name: files-mcp-e2e
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/agynio/files-mcp
 go 1.25.7
 
 require (
+	github.com/google/uuid v1.6.0
 	github.com/modelcontextprotocol/go-sdk v1.4.1
 	google.golang.org/grpc v1.79.2
 	google.golang.org/protobuf v1.36.11

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -3,7 +3,108 @@
 
 package e2e
 
-import "testing"
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	filesv1 "github.com/agynio/files-mcp/.gen/go/agynio/api/files/v1"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+const requestTimeout = 30 * time.Second
+
+var (
+	filesAddress = envOrDefault("FILES_ADDRESS", "files:50051")
+	mcpBaseURL   = envOrDefault("MCP_BASE_URL", "http://files-mcp:8100")
+)
+
+func envOrDefault(key string, fallback string) string {
+	value := strings.TrimSpace(os.Getenv(key))
+	if value == "" {
+		return fallback
+	}
+	return value
+}
+
+func TestMain(m *testing.M) {
+	os.Exit(m.Run())
+}
+
+func connectMCP(t *testing.T) *mcp.ClientSession {
+	t.Helper()
+	client := mcp.NewClient(&mcp.Implementation{Name: "files-mcp-e2e", Version: "0.1.0"}, nil)
+	transport := &mcp.StreamableClientTransport{Endpoint: mcpBaseURL}
+	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+	t.Cleanup(cancel)
+
+	session, err := client.Connect(ctx, transport, nil)
+	if err != nil {
+		t.Fatalf("connect mcp: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = session.Close()
+	})
+	return session
+}
+
+func uploadTestFile(t *testing.T, filename string, contentType string, content []byte) string {
+	t.Helper()
+	conn, err := grpc.NewClient(filesAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("dial files service: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = conn.Close()
+	})
+	client := filesv1.NewFilesServiceClient(conn)
+
+	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+	t.Cleanup(cancel)
+	stream, err := client.UploadFile(ctx)
+	if err != nil {
+		t.Fatalf("create upload stream: %v", err)
+	}
+
+	metadata := &filesv1.UploadFileMetadata{
+		Filename:    filename,
+		ContentType: contentType,
+		SizeBytes:   int64(len(content)),
+	}
+	if err := stream.Send(&filesv1.UploadFileRequest{Payload: &filesv1.UploadFileRequest_Metadata{Metadata: metadata}}); err != nil {
+		t.Fatalf("send metadata: %v", err)
+	}
+	if err := stream.Send(&filesv1.UploadFileRequest{Payload: &filesv1.UploadFileRequest_Chunk{Chunk: &filesv1.UploadFileChunk{Data: content}}}); err != nil {
+		t.Fatalf("send chunk: %v", err)
+	}
+
+	resp, err := stream.CloseAndRecv()
+	if err != nil {
+		t.Fatalf("close upload stream: %v", err)
+	}
+	if resp == nil || resp.GetFile() == nil || resp.GetFile().GetId() == "" {
+		t.Fatalf("upload response missing file info")
+	}
+	return resp.GetFile().GetId()
+}
+
+func callReadFile(t *testing.T, session *mcp.ClientSession, fileID string) *mcp.CallToolResult {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+	t.Cleanup(cancel)
+	result, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "read_file",
+		Arguments: map[string]any{"file_id": fileID},
+	})
+	if err != nil {
+		t.Fatalf("call read_file: %v", err)
+	}
+	return result
+}
 
 func TestE2EPlaceholder(t *testing.T) {
 	t.Skip("e2e tests require the full platform stack")

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -105,7 +105,3 @@ func callReadFile(t *testing.T, session *mcp.ClientSession, fileID string) *mcp.
 	}
 	return result
 }
-
-func TestE2EPlaceholder(t *testing.T) {
-	t.Skip("e2e tests require the full platform stack")
-}

--- a/test/e2e/read_file_test.go
+++ b/test/e2e/read_file_test.go
@@ -3,8 +3,173 @@
 
 package e2e
 
-import "testing"
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
 
-func TestReadFilePlaceholder(t *testing.T) {
-	t.Skip("e2e tests require Files service + Gateway deployments")
+	"github.com/google/uuid"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+var png1x1 = []byte{
+	0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44,
+	0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1f,
+	0x15, 0xc4, 0x89, 0x00, 0x00, 0x00, 0x0a, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9c, 0x63, 0x60,
+	0x00, 0x00, 0x00, 0x02, 0x00, 0x01, 0xe5, 0x27, 0xd4, 0xa2, 0x00, 0x00, 0x00, 0x00, 0x49,
+	0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+}
+
+func TestReadFileTextRoundTrip(t *testing.T) {
+	session := connectMCP(t)
+	content := "hello files-mcp"
+	fileID := uploadTestFile(t, "hello.txt", "text/plain", []byte(content))
+
+	result := callReadFile(t, session, fileID)
+	if result.IsError {
+		t.Fatalf("expected success result")
+	}
+	text := requireTextContent(t, result)
+	if text.Text != content {
+		t.Fatalf("text content = %q, want %q", text.Text, content)
+	}
+}
+
+func TestReadFileJSONRoundTrip(t *testing.T) {
+	session := connectMCP(t)
+	content := `{"ok":true}`
+	fileID := uploadTestFile(t, "payload.json", "application/json", []byte(content))
+
+	result := callReadFile(t, session, fileID)
+	if result.IsError {
+		t.Fatalf("expected success result")
+	}
+	text := requireTextContent(t, result)
+	if text.Text != content {
+		t.Fatalf("json content = %q, want %q", text.Text, content)
+	}
+}
+
+func TestReadFileImageRoundTrip(t *testing.T) {
+	session := connectMCP(t)
+	fileID := uploadTestFile(t, "pixel.png", "image/png", png1x1)
+
+	result := callReadFile(t, session, fileID)
+	if result.IsError {
+		t.Fatalf("expected success result")
+	}
+	image := requireImageContent(t, result)
+	if image.MIMEType != "image/png" {
+		t.Fatalf("mime type = %q, want %q", image.MIMEType, "image/png")
+	}
+	if !bytes.Equal(image.Data, png1x1) {
+		t.Fatalf("image data mismatch")
+	}
+}
+
+func TestReadFileBinaryRoundTrip(t *testing.T) {
+	session := connectMCP(t)
+	content := []byte("%PDF-1.4\n%EOF\n")
+	fileID := uploadTestFile(t, "document.pdf", "application/pdf", content)
+
+	result := callReadFile(t, session, fileID)
+	if result.IsError {
+		t.Fatalf("expected success result")
+	}
+	resource := requireResourceContent(t, result)
+	if resource.URI != fmt.Sprintf("agyn://file/%s", fileID) {
+		t.Fatalf("resource uri = %q, want %q", resource.URI, fmt.Sprintf("agyn://file/%s", fileID))
+	}
+	if resource.MIMEType != "application/pdf" {
+		t.Fatalf("resource mime = %q, want %q", resource.MIMEType, "application/pdf")
+	}
+	if !bytes.Equal(resource.Blob, content) {
+		t.Fatalf("resource blob mismatch")
+	}
+}
+
+func TestReadFileNotFound(t *testing.T) {
+	session := connectMCP(t)
+	missingID := uuid.NewString()
+
+	result := callReadFile(t, session, missingID)
+	if !result.IsError {
+		t.Fatalf("expected error result")
+	}
+	text := requireTextContent(t, result)
+	expected := fmt.Sprintf("file not found: %s", missingID)
+	if !strings.Contains(text.Text, expected) {
+		t.Fatalf("error text = %q, want %q", text.Text, expected)
+	}
+}
+
+func TestReadFileEmptyID(t *testing.T) {
+	session := connectMCP(t)
+
+	result := callReadFile(t, session, "")
+	if !result.IsError {
+		t.Fatalf("expected error result")
+	}
+	text := requireTextContent(t, result)
+	if text.Text != "file_id is required" {
+		t.Fatalf("error text = %q, want %q", text.Text, "file_id is required")
+	}
+}
+
+func TestReadFileListTools(t *testing.T) {
+	session := connectMCP(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+	t.Cleanup(cancel)
+	result, err := session.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("list tools: %v", err)
+	}
+	if len(result.Tools) != 1 {
+		t.Fatalf("tools length = %d, want 1", len(result.Tools))
+	}
+	if result.Tools[0].Name != "read_file" {
+		t.Fatalf("tool name = %q, want %q", result.Tools[0].Name, "read_file")
+	}
+}
+
+func requireTextContent(t *testing.T, result *mcp.CallToolResult) *mcp.TextContent {
+	t.Helper()
+	if len(result.Content) != 1 {
+		t.Fatalf("content length = %d, want 1", len(result.Content))
+	}
+	text, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("content type = %T, want *mcp.TextContent", result.Content[0])
+	}
+	return text
+}
+
+func requireImageContent(t *testing.T, result *mcp.CallToolResult) *mcp.ImageContent {
+	t.Helper()
+	if len(result.Content) != 1 {
+		t.Fatalf("content length = %d, want 1", len(result.Content))
+	}
+	image, ok := result.Content[0].(*mcp.ImageContent)
+	if !ok {
+		t.Fatalf("content type = %T, want *mcp.ImageContent", result.Content[0])
+	}
+	return image
+}
+
+func requireResourceContent(t *testing.T, result *mcp.CallToolResult) *mcp.ResourceContents {
+	t.Helper()
+	if len(result.Content) != 1 {
+		t.Fatalf("content length = %d, want 1", len(result.Content))
+	}
+	resource, ok := result.Content[0].(*mcp.EmbeddedResource)
+	if !ok {
+		t.Fatalf("content type = %T, want *mcp.EmbeddedResource", result.Content[0])
+	}
+	if resource.Resource == nil {
+		t.Fatalf("resource contents missing")
+	}
+	return resource.Resource
 }

--- a/test/e2e/read_file_test.go
+++ b/test/e2e/read_file_test.go
@@ -22,6 +22,8 @@ var png1x1 = []byte{
 	0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
 }
 
+const readFileToolDescription = "Read a file from the platform. Use this tool to access file content when you see agyn://file/ references in the conversation."
+
 func TestReadFileTextRoundTrip(t *testing.T) {
 	session := connectMCP(t)
 	content := "hello files-mcp"
@@ -132,6 +134,9 @@ func TestReadFileListTools(t *testing.T) {
 	}
 	if result.Tools[0].Name != "read_file" {
 		t.Fatalf("tool name = %q, want %q", result.Tools[0].Name, "read_file")
+	}
+	if result.Tools[0].Description != readFileToolDescription {
+		t.Fatalf("tool description = %q, want %q", result.Tools[0].Description, readFileToolDescription)
 	}
 }
 


### PR DESCRIPTION
## Summary
- replace placeholder e2e tests with real MCP/Gateway/Files round-trip coverage
- add helper utilities for MCP connect and Files upload
- configure devspace e2e runner env vars

## Testing
- buf generate buf.build/agynio/api --include-imports --path agynio/api/files/v1 --path agynio/api/gateway/v1/files.proto
- go vet ./...
- go test ./...
- go test -c -tags e2e ./test/e2e -o /tmp/files-mcp-e2e.test

Closes #3