### PR TITLE
test(e2e): run MCP tests in-process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,81 +38,23 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
-    permissions:
-      contents: read
-      packages: write
     steps:
-      - name: Free disk space
-        run: |
-          sudo rm -rf /usr/lib/jvm
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/share/swift
-          sudo rm -rf /usr/local/.ghcup
-          sudo rm -rf /usr/local/julia*
-          sudo rm -rf /usr/local/lib/android
-
-      - name: Checkout service repo
+      - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set PR image tag
-        run: echo "PR_IMAGE=ghcr.io/agynio/files-mcp:pr-${{ github.event.pull_request.number || github.run_id }}-${{ github.sha }}" >> $GITHUB_ENV
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
+      - name: Set up Go
+        uses: actions/setup-go@v5
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          go-version: '1.25'
 
-      - name: Build and push PR image
-        uses: docker/build-push-action@v6
+      - name: Setup Buf
+        uses: bufbuild/buf-setup-action@v1
         with:
-          context: .
-          push: true
-          tags: ${{ env.PR_IMAGE }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          version: 1.66.0
 
-      - name: Checkout bootstrap
-        uses: actions/checkout@v4
-        with:
-          repository: agynio/bootstrap
-          ref: main
-          path: bootstrap
-
-      - name: Install kubectl
-        uses: azure/setup-kubectl@v4
-        with:
-          version: v1.28.7
-
-      - name: Install k3d
-        run: |
-          curl -s https://raw.githubusercontent.com/k3d-io/k3d/v5.7.5/install.sh | TAG=v5.7.5 bash
-          k3d version
-
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: 1.6.6
-
-      - name: Install DevSpace
-        run: |
-          curl -fsSL -o devspace "https://github.com/loft-sh/devspace/releases/download/v6.3.20/devspace-linux-amd64"
-          sudo install -c -m 0755 devspace /usr/local/bin
-          devspace version
-
-      - name: Provision cluster
-        working-directory: bootstrap
-        run: ./apply.sh -y
-
-      - name: Verify cluster health
-        working-directory: bootstrap
-        run: ./.github/scripts/verify_platform_health.sh
+      - name: Generate protobuf stubs
+        run: buf generate buf.build/agynio/api --include-imports --path agynio/api/files/v1 --path agynio/api/gateway/v1/files.proto
 
       - name: Run E2E tests
-        env:
-          KUBECONFIG: ${{ github.workspace }}/bootstrap/stacks/k8s/.kube/agyn-local-kubeconfig.yaml
-          PR_IMAGE: ${{ env.PR_IMAGE }}
-        run: devspace run-pipeline test-e2e
+        run: go test -tags e2e ./test/e2e/

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -2,7 +2,6 @@ version: v2beta1
 
 vars:
   FILES_MCP_NAMESPACE: platform
-  E2E_IMAGE: ghcr.io/agynio/devcontainer-go:1
 
 functions:
   disable_argocd_sync: |-
@@ -40,7 +39,7 @@ functions:
               emptyDir: {}
           containers:
             - name: files-mcp
-              image: ghcr.io/agynio/devcontainer-go:1 # keep in sync with E2E_IMAGE
+              image: ghcr.io/agynio/devcontainer-go:1
               workingDir: /opt/app/data
               command:
                 - sh
@@ -76,39 +75,6 @@ functions:
                   type: RuntimeDefault
     EOF
     )"
-  deploy_pr_image: |-
-    echo "Deploying PR image to cluster..."
-    IMAGE="${PR_IMAGE:-}"
-    if [ -z "$IMAGE" ]; then
-      echo "ERROR: PR_IMAGE not set, aborting hot deploy"
-      exit 1
-    fi
-    kubectl set image deployment/files-mcp-files-mcp files-mcp="$IMAGE" -n ${FILES_MCP_NAMESPACE}
-    kubectl rollout status deployment/files-mcp-files-mcp -n ${FILES_MCP_NAMESPACE} --timeout=120s
-    echo "PR image deployed successfully"
-
-deployments:
-  e2e-runner:
-    namespace: ${FILES_MCP_NAMESPACE}
-    helm:
-      chart:
-        name: component-chart
-        repo: https://charts.devspace.sh
-      values:
-        containers:
-          - image: ${E2E_IMAGE}
-            env:
-              - name: FILES_ADDRESS
-                value: "files:50051"
-              - name: MCP_BASE_URL
-                value: "http://files-mcp:8100"
-        labels:
-          app.kubernetes.io/name: files-mcp-e2e
-
-commands:
-  test-e2e: |-
-    devspace run-pipeline test-e2e $@
-
 pipelines:
   dev:
     flags:
@@ -138,25 +104,6 @@ pipelines:
         echo "Dev environment ready. Stopping dev session."
         stop_dev files-mcp
       fi
-
-  test-e2e:
-    run: |-
-      disable_argocd_sync
-      deploy_pr_image
-      create_deployments e2e-runner
-      start_dev e2e-runner &
-      sleep 5
-      set +e
-      exec_container \
-        --label-selector "app.kubernetes.io/name=files-mcp-e2e" \
-        -n ${FILES_MCP_NAMESPACE} \
-        -- bash -c 'cd /opt/app/data && buf generate buf.build/agynio/api --include-imports --path agynio/api/files/v1 --path agynio/api/gateway/v1/files.proto && go test -v -count=1 -tags e2e ./test/e2e/'
-      EXIT_CODE=$?
-      set -e
-      stop_dev e2e-runner
-      purge_deployments e2e-runner
-      restore_argocd_sync
-      exit ${EXIT_CODE}
 
 hooks:
   - name: restore-argocd-auto-sync
@@ -198,17 +145,3 @@ dev:
           lastLines: 200
     ports:
       - port: "8100"
-
-  e2e-runner:
-    namespace: ${FILES_MCP_NAMESPACE}
-    labelSelector:
-      app.kubernetes.io/name: files-mcp-e2e
-    command: ["sleep", "infinity"]
-    workingDir: /opt/app/data
-    sync:
-      - path: ./:/opt/app/data
-        excludePaths:
-          - .git/
-          - .devspace/
-          - /.gen/
-          - /tmp/

--- a/test/e2e/fake_files.go
+++ b/test/e2e/fake_files.go
@@ -1,0 +1,100 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"sync"
+
+	filesv1 "github.com/agynio/files-mcp/.gen/go/agynio/api/files/v1"
+	"github.com/agynio/files-mcp/internal/filesclient"
+	"github.com/agynio/files-mcp/internal/mcpserver"
+	"github.com/google/uuid"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type fakeFiles struct {
+	mu    sync.Mutex
+	files map[string]fakeFile
+}
+
+type fakeFile struct {
+	info    *filesv1.FileInfo
+	content []byte
+}
+
+func newFakeFiles() *fakeFiles {
+	return &fakeFiles{files: make(map[string]fakeFile)}
+}
+
+func (f *fakeFiles) Upload(filename string, contentType string, content []byte) (string, error) {
+	filename = strings.TrimSpace(filename)
+	if filename == "" {
+		return "", errors.New("filename is required")
+	}
+	contentType = strings.TrimSpace(contentType)
+	if contentType == "" {
+		return "", errors.New("content type is required")
+	}
+
+	id := uuid.NewString()
+	record := fakeFile{
+		info: &filesv1.FileInfo{
+			Id:          id,
+			Filename:    filename,
+			ContentType: contentType,
+			SizeBytes:   int64(len(content)),
+		},
+		content: append([]byte(nil), content...),
+	}
+
+	f.mu.Lock()
+	f.files[id] = record
+	f.mu.Unlock()
+
+	return id, nil
+}
+
+func (f *fakeFiles) GetFileMetadata(ctx context.Context, fileID string) (*filesv1.FileInfo, error) {
+	record, ok := f.get(fileID)
+	if !ok {
+		return nil, status.Error(codes.NotFound, "file not found")
+	}
+	metadata := *record.info
+	return &metadata, nil
+}
+
+func (f *fakeFiles) GetFileContent(ctx context.Context, fileID string) (filesclient.FileContentStream, error) {
+	record, ok := f.get(fileID)
+	if !ok {
+		return nil, status.Error(codes.NotFound, "file not found")
+	}
+	return &fakeFileStream{data: append([]byte(nil), record.content...)}, nil
+}
+
+func (f *fakeFiles) get(fileID string) (fakeFile, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	record, ok := f.files[fileID]
+	return record, ok
+}
+
+type fakeFileStream struct {
+	data []byte
+	sent bool
+}
+
+func (f *fakeFileStream) Recv() (*filesv1.GetFileContentResponse, error) {
+	if f.sent {
+		return nil, io.EOF
+	}
+	f.sent = true
+	return &filesv1.GetFileContentResponse{ChunkData: f.data}, nil
+}
+
+var _ mcpserver.FilesClient = (*fakeFiles)(nil)

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -5,34 +5,35 @@ package e2e
 
 import (
 	"context"
+	"net/http/httptest"
 	"os"
-	"strings"
 	"testing"
 	"time"
 
-	filesv1 "github.com/agynio/files-mcp/.gen/go/agynio/api/files/v1"
+	"github.com/agynio/files-mcp/internal/mcpserver"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 )
 
-const requestTimeout = 30 * time.Second
+const (
+	requestTimeout = 30 * time.Second
+	maxFileSize    = int64(20 * 1024 * 1024)
+)
 
 var (
-	filesAddress = envOrDefault("FILES_ADDRESS", "files:50051")
-	mcpBaseURL   = envOrDefault("MCP_BASE_URL", "http://files-mcp:8100")
+	mcpBaseURL       string
+	mcpServer        *httptest.Server
+	fakeFilesBackend *fakeFiles
 )
 
-func envOrDefault(key string, fallback string) string {
-	value := strings.TrimSpace(os.Getenv(key))
-	if value == "" {
-		return fallback
-	}
-	return value
-}
-
 func TestMain(m *testing.M) {
-	os.Exit(m.Run())
+	fakeFilesBackend = newFakeFiles()
+	server := mcpserver.New(fakeFilesBackend, mcpserver.Options{MaxFileSize: maxFileSize})
+	mcpServer = httptest.NewServer(server.Handler())
+	mcpBaseURL = mcpServer.URL
+
+	exitCode := m.Run()
+	mcpServer.Close()
+	os.Exit(exitCode)
 }
 
 func connectMCP(t *testing.T) *mcp.ClientSession {
@@ -54,42 +55,11 @@ func connectMCP(t *testing.T) *mcp.ClientSession {
 
 func uploadTestFile(t *testing.T, filename string, contentType string, content []byte) string {
 	t.Helper()
-	conn, err := grpc.NewClient(filesAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	fileID, err := fakeFilesBackend.Upload(filename, contentType, content)
 	if err != nil {
-		t.Fatalf("dial files service: %v", err)
+		t.Fatalf("upload file: %v", err)
 	}
-	t.Cleanup(func() {
-		_ = conn.Close()
-	})
-	client := filesv1.NewFilesServiceClient(conn)
-
-	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
-	t.Cleanup(cancel)
-	stream, err := client.UploadFile(ctx)
-	if err != nil {
-		t.Fatalf("create upload stream: %v", err)
-	}
-
-	metadata := &filesv1.UploadFileMetadata{
-		Filename:    filename,
-		ContentType: contentType,
-		SizeBytes:   int64(len(content)),
-	}
-	if err := stream.Send(&filesv1.UploadFileRequest{Payload: &filesv1.UploadFileRequest_Metadata{Metadata: metadata}}); err != nil {
-		t.Fatalf("send metadata: %v", err)
-	}
-	if err := stream.Send(&filesv1.UploadFileRequest{Payload: &filesv1.UploadFileRequest_Chunk{Chunk: &filesv1.UploadFileChunk{Data: content}}}); err != nil {
-		t.Fatalf("send chunk: %v", err)
-	}
-
-	resp, err := stream.CloseAndRecv()
-	if err != nil {
-		t.Fatalf("close upload stream: %v", err)
-	}
-	if resp == nil || resp.GetFile() == nil || resp.GetFile().GetId() == "" {
-		t.Fatalf("upload response missing file info")
-	}
-	return resp.GetFile().GetId()
+	return fileID
 }
 
 func callReadFile(t *testing.T, session *mcp.ClientSession, fileID string) *mcp.CallToolResult {


### PR DESCRIPTION
## Summary
- add in-memory fake files backend for e2e MCP server
- run e2e tests against in-process httptest server
- simplify CI and DevSpace e2e wiring

## Testing
- buf generate buf.build/agynio/api --include-imports --path agynio/api/files/v1 --path agynio/api/gateway/v1/files.proto
- go vet ./...
- go test ./...
- go test -tags e2e ./test/e2e/

## Issue
- #7