### PR TITLE
Align CI with centralized E2E workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -35,26 +38,3 @@ jobs:
 
       - name: Go test
         run: go test ./...
-
-  e2e:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.25'
-
-      - name: Setup Buf
-        uses: bufbuild/buf-setup-action@v1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          version: 1.66.0
-
-      - name: Generate protobuf stubs
-        run: buf generate buf.build/agynio/api --include-imports --path agynio/api/files/v1 --path agynio/api/gateway/v1/files.proto
-
-      - name: Run E2E tests
-        run: go test -tags e2e ./test/e2e/

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Run E2E tests
         uses: agynio/e2e/.github/actions/run-tests@main
+        env:
+          E2E_SUITES: go-core
         with:
-          tag: svc_gateway
+          tag: svc_files
           include_smoke: false

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,31 @@
+name: E2E
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Provision cluster
+        uses: agynio/bootstrap/.github/actions/provision@main
+
+      - name: Setup DevSpace
+        uses: agynio/e2e/.github/actions/setup-devspace@main
+
+      - name: Deploy files-mcp from source
+        run: devspace dev
+
+      - name: Run E2E tests
+        uses: agynio/e2e/.github/actions/run-tests@main
+        with:
+          service: files_mcp

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,4 +28,5 @@ jobs:
       - name: Run E2E tests
         uses: agynio/e2e/.github/actions/run-tests@main
         with:
-          service: files_mcp
+          tag: svc_gateway
+          include_smoke: false

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -81,9 +81,6 @@ deployments:
               requests:
                 cpu: 500m
                 memory: 1Gi
-              limits:
-                cpu: "2"
-                memory: 4Gi
         service:
           ports:
             - name: http
@@ -153,6 +150,8 @@ dev:
               - .devspace/
               - /.gen/
               - /tmp/
+              - /e2e/
+              - /bootstrap/
             downloadExcludePaths:
               - .git/
               - .devspace/

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -2,6 +2,7 @@ version: v2beta1
 
 vars:
   FILES_MCP_NAMESPACE: platform
+  DEV_IMAGE: ghcr.io/agynio/devcontainer-go:1
 
 functions:
   disable_argocd_sync: |-
@@ -24,57 +25,74 @@ functions:
     else
       echo "WARNING: ArgoCD Application 'files-mcp' not found in argocd namespace."
     fi
-  patch_deployment: |-
-    echo "Patching files-mcp deployment for DevSpace..."
-    kubectl patch deployment files-mcp-files-mcp -n ${FILES_MCP_NAMESPACE} --type strategic --patch "$(cat <<'EOF'
-    spec:
-      template:
-        spec:
-          securityContext:
-            runAsUser: 1000
-            fsGroup: 1000
-          initContainers: []
-          volumes:
-            - name: data
-              emptyDir: {}
-          containers:
-            - name: files-mcp
-              image: ghcr.io/agynio/devcontainer-go:1
-              workingDir: /opt/app/data
-              command:
-                - sh
-                - -c
-                - |
-                  set -eu
-                  elapsed=0
-                  while [ ! -f /opt/app/data/go.mod ]; do
-                    sleep 1; elapsed=$((elapsed + 1))
-                    [ "$elapsed" -ge 120 ] && { echo "ERROR: sync timeout" >&2; exit 1; }
-                  done
-                  buf generate buf.build/agynio/api --include-imports --path agynio/api/files/v1 --path agynio/api/gateway/v1/files.proto
-                  exec go run ./cmd/files-mcp
-              volumeMounts:
-                - name: data
-                  mountPath: /opt/app/data
-              resources:
-                requests:
-                  cpu: 500m
-                  memory: 1Gi
-                limits:
-                  cpu: "2"
-                  memory: 4Gi
-              securityContext:
-                runAsNonRoot: true
-                runAsUser: 1000
-                runAsGroup: 1000
-                readOnlyRootFilesystem: false
-                allowPrivilegeEscalation: false
-                capabilities:
-                  drop: ["ALL"]
-                seccompProfile:
-                  type: RuntimeDefault
-    EOF
-    )"
+deployments:
+  files-mcp:
+    namespace: ${FILES_MCP_NAMESPACE}
+    helm:
+      chart:
+        name: component-chart
+        repo: https://charts.devspace.sh
+      values:
+        labels:
+          app.kubernetes.io/name: files-mcp
+          app.kubernetes.io/instance: files-mcp
+        containers:
+          - name: files-mcp
+            image: ${DEV_IMAGE}
+            workingDir: /opt/app/data
+            command:
+              - sh
+              - -c
+              - |
+                set -eu
+                elapsed=0
+                while [ ! -f /opt/app/data/go.mod ]; do
+                  sleep 1; elapsed=$((elapsed + 1))
+                  [ "$elapsed" -ge 120 ] && { echo "ERROR: sync timeout" >&2; exit 1; }
+                done
+                buf generate buf.build/agynio/api --include-imports --path agynio/api/files/v1 --path agynio/api/gateway/v1/files.proto
+                exec go run ./cmd/files-mcp
+            env:
+              - name: MCP_PORT
+                value: "8100"
+              - name: GATEWAY_ADDRESS
+                value: gateway.ziti
+              - name: MAX_FILE_SIZE
+                value: "20971520"
+            ports:
+              - name: http
+                containerPort: 8100
+            volumeMounts:
+              - containerPath: /opt/app/data
+                volume:
+                  name: data
+            securityContext:
+              runAsNonRoot: true
+              runAsUser: 1000
+              runAsGroup: 1000
+              readOnlyRootFilesystem: false
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+              seccompProfile:
+                type: RuntimeDefault
+            resources:
+              requests:
+                cpu: 500m
+                memory: 1Gi
+              limits:
+                cpu: "2"
+                memory: 4Gi
+        service:
+          ports:
+            - name: http
+              port: 8100
+              containerPort: 8100
+        volumes:
+          - name: data
+            emptyDir: {}
+
 pipelines:
   dev:
     flags:
@@ -83,7 +101,7 @@ pipelines:
         description: "Keep DevSpace running and stream logs"
     run: |-
       disable_argocd_sync
-      patch_deployment
+      create_deployments files-mcp
       if [ "$(get_flag "watch")" == "true" ]; then
         start_dev --disable-pod-replace files-mcp
       else


### PR DESCRIPTION
## Summary
- Moves the E2E job out of CI into a centralized E2E workflow that composes `agynio/bootstrap/.github/actions/provision@main`, `devspace dev`, and `agynio/e2e/.github/actions/run-tests@main`.
- Keeps PR CI limited to source validation with no image/chart publishing.
- Adds read-only workflow permissions to CI/E2E.
- Verified no cluster environment overrides are set and shared agynio action refs use `@main` only.

Closes #10

## Test & Lint Summary
- `actionlint .github/workflows/ci.yml .github/workflows/e2e.yml .github/workflows/release.yml` — passed with no errors.
- `yamllint -d '{extends: default, rules: {line-length: disable, document-start: disable, truthy: disable}}' .github/workflows/ci.yml .github/workflows/e2e.yml .github/workflows/release.yml devspace.yaml` — passed with no errors.
- `buf generate buf.build/agynio/api --include-imports --path agynio/api/files/v1 --path agynio/api/gateway/v1/files.proto` — passed.
- `gofmt -w $(find cmd internal test -name '*.go' -print)` — passed with no committed changes.
- `go vet ./...` — passed with no errors.
- `go test ./...` — 2 packages passed, 0 failed, 0 skipped.
- `go test -tags e2e ./test/e2e/` — 1 package passed, 0 failed, 0 skipped.
- `go build ./...` — passed.
- `devspace print --debug` — passed.